### PR TITLE
Remove support for unused oneway=true, see abrensch/brouter#416

### DIFF
--- a/Trekking-No-Flat.brf
+++ b/Trekking-No-Flat.brf
@@ -159,7 +159,7 @@ assign accesspenalty =
 # to push your bike)
 #
 assign oneway =
-       if oneway= then junction=roundabout else oneway=yes|true|1
+       if oneway= then junction=roundabout else oneway=yes|1
 
 assign onewaypenalty =
        if ( if reversedirection=yes then oneway else oneway=-1 ) then

--- a/Trekking-Poutnik.brf
+++ b/Trekking-Poutnik.brf
@@ -217,7 +217,7 @@ assign badoneway =
        if reversedirection=yes then
          if oneway:bicycle=yes then true  
          else if oneway= then junction=roundabout 
-         else oneway=yes|true|1
+         else oneway=yes|1
        else oneway=-1
 
 assign onewaypenalty = 
@@ -518,7 +518,7 @@ assign priorityclassifier = (
 
 assign isbadoneway = not equal onewaypenalty 0
 assign isgoodoneway = if reversedirection=yes then oneway=-1
-                      else if oneway= then junction=roundabout else oneway=yes|true|1
+                      else if oneway= then junction=roundabout else oneway=yes|1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true

--- a/Trekking-hilly-paths.brf
+++ b/Trekking-hilly-paths.brf
@@ -244,7 +244,7 @@ assign badoneway =
        if reversedirection=yes then
          if oneway:bicycle=yes then true  # added in v 
          else if oneway= then junction=roundabout 
-         else oneway=yes|true|1
+         else oneway=yes|1
        else oneway=-1
        
        
@@ -643,7 +643,7 @@ assign priorityclassifier = (
 
 assign isbadoneway = not equal onewaypenalty 0
 assign isgoodoneway = if reversedirection=yes then oneway=-1
-                      else if oneway= then junction=roundabout else oneway=yes|true|1
+                      else if oneway= then junction=roundabout else oneway=yes|1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true

--- a/Trekking-tracks.brf
+++ b/Trekking-tracks.brf
@@ -245,7 +245,7 @@ assign badoneway =
        if reversedirection=yes then
          if oneway:bicycle=yes then true  # added in v 
          else if oneway= then junction=roundabout 
-         else oneway=yes|true|1
+         else oneway=yes|1
        else oneway=-1
        
        
@@ -644,7 +644,7 @@ assign priorityclassifier = (
 
 assign isbadoneway = not equal onewaypenalty 0
 assign isgoodoneway = if reversedirection=yes then oneway=-1
-                      else if oneway= then junction=roundabout else oneway=yes|true|1
+                      else if oneway= then junction=roundabout else oneway=yes|1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true

--- a/Trekking-valley.brf
+++ b/Trekking-valley.brf
@@ -196,7 +196,7 @@ assign accesspenalty =
 #
 assign badoneway =
        if reversedirection=yes then
-         if oneway= then junction=roundabout else oneway=yes|true|1
+         if oneway= then junction=roundabout else oneway=yes|1
        else oneway=-1
        
 
@@ -515,7 +515,7 @@ assign priorityclassifier =
 
 assign isbadoneway = not equal onewaypenalty 0
 assign isgoodoneway = if reversedirection=yes then oneway=-1
-                      else if oneway= then junction=roundabout else oneway=yes|true|1
+                      else if oneway= then junction=roundabout else oneway=yes|1
 assign isroundabout = junction=roundabout
 assign islinktype = highway=motorway_link|trunk_link|primary_link|secondary_link|tertiary_link
 assign isgoodforcars = if greater priorityclassifier 6 then true


### PR DESCRIPTION
See abrensch/brouter#416, there ios the plan to update lookups.dat and remove some unused tags.

One of these tags is oneway=true, https://taginfo.openstreetmap.org/keys/oneway#values

This patch removes oneway=true for these template profiles